### PR TITLE
RPM for SUSE

### DIFF
--- a/lib/bunchr/packages.rb
+++ b/lib/bunchr/packages.rb
@@ -10,7 +10,7 @@ module Bunchr
 
     # only attempt to build .rpm's on these platforms (as reported by
     # ohai.platform)
-    RPM_PLATFORMS = %w[centos redhat fedora scientific]
+    RPM_PLATFORMS = %w[centos redhat fedora scientific suse]
 
     # only attempt to build .deb's on these platforms (as reported by
     # ohai.platform)


### PR DESCRIPTION
Hi!
Happy new year ;-)

Here's one small bit of the required work to get Sensu built & installed on suse variants.

The main motive is that SAP uses SLES for many big-boy products & clusters. Getting Suse support enables me to push Sensu into some serious installations.

Additional elements that need to go in:
1. A new Veewee template for SLES 11SP2 - https://github.com/jedi4ever/veewee/pull/457.
The existing SLES image is old & a bit broken, and so is the openSUSE one...I may try to address that as well.
2. A fix for Vagrant itself, to successfully change the host name on suse (which sensu-build does) - 
https://github.com/mitchellh/vagrant/pull/1283
Seems it would be a while before Vagrant 1.1.0 is available, because it's a major change. I can easily provide a monkey patch for this in sensu-build, dependent on version - but that can wait I guess. Something for @portertech to also think about?
3. Changes to sensu-build - https://github.com/eladroz/sensu-build/commit/1345785c0934af13b0cf8470a6c7a1da4dde7944
Did not make a pull request still, have to polish some details.

Bottom line, I built, installed & ran the Sensu components on both SLES11SP2 & openSUSE 12.1 (x64 versions only), for versions 0.9.7 & 0.9.9.beta.1 (not all variations tested thoguh...). I didn't try however to run rabbitmq / redis there yet, so connected to another server for now. 
If you & @portertech want all this stuff in, I'd be glad to follow up with the sensu-chef bits, and setting a suse-friendly repo.

Cheers,
Elad
