### PR TITLE
Add raspbian to Debian family

### DIFF
--- a/lib/bunchr/packages.rb
+++ b/lib/bunchr/packages.rb
@@ -14,7 +14,7 @@ module Bunchr
 
     # only attempt to build .deb's on these platforms (as reported by
     # ohai.platform)
-    DEB_PLATFORMS = %w[debian ubuntu]
+    DEB_PLATFORMS = %w[debian ubuntu raspbian]
 
     attr_accessor :name, :version, :iteration, :license, :vendor, :url, :category
     attr_accessor :description


### PR DESCRIPTION
Raspbian is debian distribution tailored to the arm based raspberry pi
board.

See: http://www.raspbian.org/