### PR TITLE
Include raspbian in DEB_PLATFORMS

### DIFF
--- a/lib/bunchr/packages.rb
+++ b/lib/bunchr/packages.rb
@@ -14,7 +14,7 @@ module Bunchr
 
     # only attempt to build .deb's on these platforms (as reported by
     # ohai.platform)
-    DEB_PLATFORMS = %w[debian ubuntu]
+    DEB_PLATFORMS = %w[debian ubuntu raspbian]
 
     attr_accessor :name, :version, :iteration, :license, :vendor, :maintainer, :url, :category
     attr_accessor :description


### PR DESCRIPTION
Add raspbian to the list of deb platforms.  This will allow packages such as sensu/sensu-build to build on raspbian and generate packages.