### PR TITLE
Ask the packager for architecture on Debian platforms

### DIFF
--- a/lib/bunchr/packages.rb
+++ b/lib/bunchr/packages.rb
@@ -38,8 +38,8 @@ module Bunchr
       define unless name.nil? or version.nil?
     end
 
-    # 
-    # returns the current architecture. Convert some architectures for the 
+    #
+    # returns the current architecture. Convert some architectures for the
     # underlying packaging systems, such as i686 to i386.
     def arch
       case @arch
@@ -66,7 +66,7 @@ module Bunchr
           # TODO-future: build solaris pkgs, windows too?!
 
           define_build_all
-          
+
           task :done    => "#{name}:build"
           task :default => "#{name}:done"
         end
@@ -112,7 +112,7 @@ module Bunchr
         else
           logger.info "Not building RPM, platform [#{ohai.platform}] does not support it."
         end
-        
+
       end
     end
 
@@ -121,6 +121,8 @@ module Bunchr
       task :build_deb do
 
         if DEB_PLATFORMS.include? ohai.platform
+           # Instead of guessing architecture from the kernel, ask the packager
+          @arch = `dpkg --print-architecture`.strip()
           logger.info "Building DEB '#{name}-#{version}-#{iteration}-#{arch}'"
 
           sh "fpm -s dir -t deb -a #{arch} -n #{name} -v #{version} \
@@ -159,7 +161,7 @@ module Bunchr
     end
 
     # return an argument string for fpm with '--config-files' prefixed to
-    # every file in the config_files array. 
+    # every file in the config_files array.
     #   eg: '--config-files /etc/file1 --config-files /etc/file2'
     def fpm_config_files_args
       config_files.map { |f| '--config-files ' + f }.join(' ')


### PR DESCRIPTION
Debain has some strage ideas about what the package platform
should be, and it doesn't line up well with the kernel machine
in many cases. Instead of guessing, or having a lot of logic to
fix the architecture, we'll just ask dpkg for the correct one.

This works great when you have something like an ARMv7 host
and you are compiling for the armhf and armel architectures in
a container or chroot.

I haven't figured out how to effectively duplicate this with RPM
since this uses fpm to generate the package and not all RPM
tools are guaranteed to be installed on the host.
